### PR TITLE
feat: Cost-aware LLM pipeline with model routing

### DIFF
--- a/agents/cost-router/AGENT.md
+++ b/agents/cost-router/AGENT.md
@@ -1,0 +1,178 @@
+# Cost-Router Agent
+
+## Identity
+
+**Name:** cost-router  
+**Role:** LLM call interceptor and model selector  
+**Model:** claude-3-5-haiku (the router itself must be cheap)  
+**Latency SLA:** <200ms routing decision
+
+---
+
+## Purpose
+
+The cost-router sits between every agent and the Anthropic API. Before any LLM call is dispatched, the cost-router:
+
+1. Scores the request complexity (0–10)
+2. Selects the appropriate model tier (Haiku / Sonnet / Opus)
+3. Checks session budget remaining
+4. Checks cache for an existing response
+5. Approves, modifies, or rejects the call
+
+This agent prevents accidental Opus usage for trivial tasks and enforces budget limits across all sessions.
+
+---
+
+## Responsibilities
+
+### 1. Complexity Scoring
+
+Analyze incoming requests and assign a complexity score:
+
+```yaml
+complexity_scoring:
+  inputs:
+    - task_description: string
+    - context_length: integer      # tokens of context provided
+    - output_length_hint: string   # "short" | "medium" | "long"
+    - task_type: string            # "lookup" | "code" | "analysis" | "architecture"
+    - criticality: string          # "low" | "medium" | "high" | "critical"
+
+  output:
+    score: integer  # 0–10
+    rationale: string
+    recommended_model: "haiku" | "sonnet" | "opus"
+```
+
+### 2. Model Selection
+
+Apply routing rules from `routing-rules.md`. Override logic:
+
+- `criticality: critical` → **minimum Sonnet** (never Haiku for critical tasks)
+- `task_type: architecture` → **minimum Opus**
+- `context_length > 100_000` → upgrade one tier (long contexts need more reasoning)
+- Explicit model override in agent config → honor it, but log the override
+
+### 3. Budget Enforcement
+
+```yaml
+budget_enforcement:
+  per_session_limit: "$0.50"
+  per_call_limit: "$0.25"
+  on_exceed:
+    per_call: downgrade_model   # try cheaper model first
+    per_session: reject_with_error
+  warn_at: 70%  # of session limit
+```
+
+### 4. Cache Lookup
+
+Before dispatching:
+1. Generate cache key from `(model, system_prompt_hash, user_prompt_hash)`
+2. Check cache store (Redis or in-memory TTL map)
+3. On hit: return cached response, log cache hit, charge $0
+4. On miss: dispatch, cache response with appropriate TTL
+
+### 5. Telemetry
+
+Emit for every call:
+
+```json
+{
+  "event": "llm_call",
+  "session_id": "...",
+  "model_requested": "opus",
+  "model_used": "sonnet",
+  "complexity_score": 6,
+  "was_downgraded": true,
+  "cache_hit": false,
+  "input_tokens": 1240,
+  "output_tokens": 380,
+  "cost_usd": 0.0472,
+  "session_total_usd": 0.183,
+  "duration_ms": 2100
+}
+```
+
+---
+
+## Agent Interface
+
+```typescript
+interface CostRouterRequest {
+  taskDescription: string;
+  systemPrompt?: string;
+  userPrompt: string;
+  contextTokens?: number;
+  taskType: 'lookup' | 'code' | 'analysis' | 'architecture' | 'other';
+  criticality: 'low' | 'medium' | 'high' | 'critical';
+  requestedModel?: 'haiku' | 'sonnet' | 'opus';  // optional override
+  sessionId: string;
+  budgetLimitUsd?: number;  // override session default
+}
+
+interface CostRouterResponse {
+  approved: boolean;
+  model: 'haiku' | 'sonnet' | 'opus';
+  wasDowngraded: boolean;
+  wasUpgraded: boolean;
+  cacheHit: boolean;
+  estimatedCostUsd: number;
+  sessionRemainingUsd: number;
+  rejectReason?: string;  // if approved = false
+}
+```
+
+---
+
+## Configuration
+
+```yaml
+# cost-router config (set in agent deployment)
+cost_router:
+  enabled: true
+  default_session_budget_usd: 0.50
+  cache:
+    enabled: true
+    backend: "redis"          # or "memory"
+    default_ttl_seconds: 3600
+  telemetry:
+    enabled: true
+    log_level: "info"
+    emit_to: "stdout"         # or "datadog" | "cloudwatch"
+  routing:
+    rules_file: "routing-rules.md"
+    allow_model_override: true  # agents can request specific model
+    log_overrides: true
+```
+
+---
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Budget exceeded (per-call) | Try downgrading model; if still over budget, reject |
+| Budget exceeded (per-session) | Reject all calls; return `approved: false` |
+| Cache backend unavailable | Log warning, proceed without cache |
+| Routing rule parse error | Default to Sonnet, log error |
+| Model unavailable (API error) | Try next tier up; if all fail, propagate error |
+
+---
+
+## Monitoring Dashboards
+
+Track these metrics in Datadog/CloudWatch/Grafana:
+
+- `cost_router.session_cost_usd` (histogram by session)
+- `cost_router.model_distribution` (% haiku/sonnet/opus)
+- `cost_router.cache_hit_rate` (%)
+- `cost_router.downgrades_total` (count)
+- `cost_router.budget_exceeded_total` (count)
+- `cost_router.p99_latency_ms` (routing overhead)
+
+**Target SLOs:**
+- Haiku usage ≥ 50%
+- Cache hit rate ≥ 20%
+- Routing overhead < 200ms p99
+- Budget exceeded events < 1% of sessions

--- a/agents/cost-router/routing-rules.md
+++ b/agents/cost-router/routing-rules.md
@@ -1,0 +1,248 @@
+# Routing Rules
+
+Complete rule set for the cost-router agent. Rules are evaluated in order; first match wins.
+
+---
+
+## Rule Structure
+
+```yaml
+rule:
+  name: string
+  conditions:
+    - field: <field>
+      operator: <eq|contains|gte|lte|in|matches>
+      value: <value>
+  model: haiku | sonnet | opus
+  rationale: string
+```
+
+---
+
+## Rules (Priority Order)
+
+### 1. Hard Overrides (highest priority)
+
+```yaml
+- name: "explicit-model-override"
+  conditions:
+    - field: requestedModel
+      operator: in
+      value: [haiku, sonnet, opus]
+    - field: criticality
+      operator: neq
+      value: critical
+  model: <requestedModel>
+  rationale: "Caller explicitly requested a model; honor unless critical"
+
+- name: "critical-minimum-sonnet"
+  conditions:
+    - field: criticality
+      operator: eq
+      value: critical
+    - field: requestedModel
+      operator: eq
+      value: haiku
+  model: sonnet
+  rationale: "Never use Haiku for critical tasks — upgrade to Sonnet minimum"
+
+- name: "architecture-requires-opus"
+  conditions:
+    - field: taskType
+      operator: eq
+      value: architecture
+  model: opus
+  rationale: "Architecture decisions need Opus reasoning depth"
+```
+
+---
+
+### 2. Task Type Rules
+
+```yaml
+- name: "lookup-to-haiku"
+  conditions:
+    - field: taskType
+      operator: eq
+      value: lookup
+  model: haiku
+  rationale: "Simple lookups: status checks, single-fact queries, yes/no"
+
+- name: "code-to-sonnet"
+  conditions:
+    - field: taskType
+      operator: eq
+      value: code
+  model: sonnet
+  rationale: "Code generation and review needs Sonnet's coding capability"
+
+- name: "analysis-to-sonnet"
+  conditions:
+    - field: taskType
+      operator: eq
+      value: analysis
+  model: sonnet
+  rationale: "Analysis and research tasks need multi-step reasoning"
+
+- name: "other-low-complexity-to-haiku"
+  conditions:
+    - field: taskType
+      operator: eq
+      value: other
+    - field: complexityScore
+      operator: lte
+      value: 3
+  model: haiku
+  rationale: "Low-complexity 'other' tasks don't need Sonnet"
+```
+
+---
+
+### 3. Complexity Score Rules
+
+```yaml
+- name: "score-0-3-haiku"
+  conditions:
+    - field: complexityScore
+      operator: lte
+      value: 3
+    - field: criticality
+      operator: in
+      value: [low, medium]
+  model: haiku
+  rationale: "Low complexity, non-critical: Haiku is sufficient"
+
+- name: "score-4-7-sonnet"
+  conditions:
+    - field: complexityScore
+      operator: gte
+      value: 4
+    - field: complexityScore
+      operator: lte
+      value: 7
+  model: sonnet
+  rationale: "Medium complexity: Sonnet handles code, research, debugging"
+
+- name: "score-8-10-opus"
+  conditions:
+    - field: complexityScore
+      operator: gte
+      value: 8
+  model: opus
+  rationale: "High complexity: Opus for architecture, critical decisions"
+```
+
+---
+
+### 4. Context Length Rules
+
+```yaml
+- name: "long-context-upgrade-haiku-to-sonnet"
+  conditions:
+    - field: contextTokens
+      operator: gte
+      value: 50000
+    - field: model
+      operator: eq
+      value: haiku
+  model: sonnet
+  rationale: "Very long contexts need better reasoning; upgrade Haiku to Sonnet"
+
+- name: "very-long-context-upgrade-sonnet-to-opus"
+  conditions:
+    - field: contextTokens
+      operator: gte
+      value: 150000
+    - field: model
+      operator: eq
+      value: sonnet
+    - field: criticality
+      operator: in
+      value: [high, critical]
+  model: opus
+  rationale: "Critical tasks with 150K+ context need Opus for reliable synthesis"
+```
+
+---
+
+### 5. Keyword Pattern Rules
+
+Applied to `taskDescription` (case-insensitive regex):
+
+```yaml
+haiku_patterns:
+  - "status (check|of|update)"
+  - "what is (the )?(current )?(status|state)"
+  - "is .* (open|closed|running|stopped|passing|failing)"
+  - "format (this|the) (json|yaml|csv|markdown|table)"
+  - "which (agent|model|workflow) should"
+  - "summarize .{0,50} (in one line|briefly|quickly)"
+  - "translate (this|the) (command|script|snippet)"
+  - "list (all |the )?(current )?(open |active )?(issues|prs|deployments)"
+  - "ping|health.?check"
+
+sonnet_patterns:
+  - "implement|build|create|add|write (a |the )?(\w+ )?(function|class|module|service|api|endpoint)"
+  - "(debug|fix|resolve|diagnose) (this |the )?(bug|error|issue|problem|race condition)"
+  - "review (this |the )?(pr|code|diff|change)"
+  - "refactor|optimize|improve"
+  - "write (tests|specs|unit tests|integration tests)"
+  - "research (which|the best|what|how)"
+  - "analyze|analyse|evaluate"
+  - "explain (how|why|what)"
+
+opus_patterns:
+  - "design (the |a )?(system|architecture|schema|database|api|platform)"
+  - "security (audit|review|assessment) .*(critical|production|customer)"
+  - "(evaluate|compare|choose between) .* (approach|option|strategy|architecture)"
+  - "root cause analysis|rca|postmortem"
+  - "migration (plan|strategy|path)"
+  - "multi.?tenant|distributed (system|architecture|locking)"
+  - "critical (decision|review|assessment)"
+  - "(long.?term|long.?horizon) (plan|strategy|roadmap)"
+```
+
+---
+
+## Examples
+
+### Routed to Haiku ✅ (cheap)
+
+| Request | Score | Reason |
+|---------|-------|--------|
+| "Is the staging deployment passing?" | 1 | Lookup, low criticality |
+| "Format this JSON as a markdown table" | 1 | Format task |
+| "Which agent should handle this iMessage?" | 2 | Routing decision |
+| "Summarize this error in one line" | 2 | Short output, trivial |
+| "List all open PRs in xom-claude-agents" | 2 | Lookup |
+
+### Routed to Sonnet ✅ (balanced)
+
+| Request | Score | Reason |
+|---------|-------|--------|
+| "Add OAuth2 to the auth module" | 5 | Code, medium complexity |
+| "Debug this race condition in the job queue" | 6 | Code + analysis |
+| "Research which job queue library to use" | 5 | Analysis, medium |
+| "Review PR #42 for bugs" | 4 | Code review, non-critical |
+| "Write tests for the payment service" | 5 | Code |
+
+### Routed to Opus ✅ (justified)
+
+| Request | Score | Reason |
+|---------|-------|--------|
+| "Design the multi-tenant database schema" | 9 | Architecture |
+| "Evaluate 3 distributed locking approaches" | 8 | High complexity, critical decision |
+| "Security audit of the API gateway (customer-facing)" | 8 | Critical, security |
+| "RCA for the P0 incident with 12 factors" | 10 | Critical, high complexity |
+| "Design our event-driven architecture migration" | 9 | Architecture, long-horizon |
+
+---
+
+## Default Rule (fallback)
+
+```yaml
+- name: "default-sonnet"
+  conditions: []  # always matches
+  model: sonnet
+  rationale: "When no rule matches, Sonnet is the safe default — better than Opus overkill or Haiku under-power"
+```

--- a/docs/cost-aware-routing.md
+++ b/docs/cost-aware-routing.md
@@ -1,0 +1,182 @@
+# Cost-Aware LLM Routing
+
+## Overview
+
+Not every task needs Opus. Routing LLM calls to the cheapest capable model is one of the highest-leverage cost optimizations available. This document defines the routing decision tree, model tiers, cost tracking approach, and caching strategy used across all Xomware agents.
+
+**Target distribution:** ~60% Haiku · ~30% Sonnet · ~10% Opus
+
+---
+
+## Model Tiers
+
+| Tier | Model | Cost (approx) | Latency | Use For |
+|------|-------|---------------|---------|---------|
+| **Haiku** | claude-3-5-haiku | ~$0.001/1K tokens | <1s | Lookup, format, triage, status, simple Q&A |
+| **Sonnet** | claude-sonnet-4 | ~$0.015/1K tokens | 2–5s | Code, analysis, research, multi-step reasoning |
+| **Opus** | claude-opus-4 | ~$0.075/1K tokens | 5–30s | Architecture, critical decisions, complex planning |
+
+Opus costs 75× more than Haiku. Routing a lookup from Opus to Haiku saves $0.074 per call. At scale, this compounds dramatically.
+
+---
+
+## Routing Decision Tree
+
+```
+Is the task simple? (lookup, status check, format, yes/no, short summary)
+  └── YES → Haiku
+  └── NO ↓
+
+Does the task require code generation, code review, or multi-step reasoning?
+  └── YES → Sonnet (unless complexity score > 8)
+  └── NO ↓
+
+Does the task require architecture decisions, critical security review,
+long-horizon planning, or synthesis of ambiguous/conflicting information?
+  └── YES → Opus
+  └── NO → Sonnet (default)
+```
+
+### Complexity Score (0–10)
+
+Assign a complexity score before routing:
+
+| Score | Description |
+|-------|-------------|
+| 0–2 | Single-fact lookup, status check, reformatting |
+| 3–4 | Short code snippets, simple explanations, routing decisions |
+| 5–6 | Multi-file code changes, debugging, research summaries |
+| 7–8 | System design, security audits, complex refactors |
+| 9–10 | Architecture decisions, cross-system integration plans, critical incident RCA |
+
+- Score 0–3 → **Haiku**
+- Score 4–7 → **Sonnet**
+- Score 8–10 → **Opus**
+
+---
+
+## Examples by Category
+
+### Always Haiku
+
+```yaml
+- "What's the current status of the deployment?"
+- "Format this JSON as a markdown table"
+- "Is PR #42 open or closed?"
+- "Summarize this error message in one line"
+- "Which agent should handle this request?"
+- "Translate this shell command to PowerShell"
+```
+
+### Always Sonnet
+
+```yaml
+- "Implement OAuth2 token refresh in the auth module"
+- "Debug this race condition in the job queue"
+- "Review this PR for obvious bugs and style issues"
+- "Research which job queue library to use for Node.js"
+- "Write tests for the payment service"
+- "Refactor this module to use dependency injection"
+```
+
+### Always Opus
+
+```yaml
+- "Design the database schema for a multi-tenant SaaS platform"
+- "Review our security model for the API gateway — this is customer-facing"
+- "We have 3 conflicting approaches to distributed locking — evaluate and recommend"
+- "Perform RCA on this P0 incident with 12 contributing factors"
+- "Design our event-driven architecture migration strategy"
+```
+
+---
+
+## Cost Tracking
+
+### Per-Session Budget
+
+Each agent session should track:
+
+```yaml
+session_budget:
+  limit_usd: 0.50        # hard limit per session
+  warn_at_usd: 0.30      # log warning when crossed
+  current_spend_usd: 0.00
+  token_counts:
+    haiku_in: 0
+    haiku_out: 0
+    sonnet_in: 0
+    sonnet_out: 0
+    opus_in: 0
+    opus_out: 0
+```
+
+### Cost Estimation Formula
+
+```
+cost = (input_tokens / 1000 * input_rate) + (output_tokens / 1000 * output_rate)
+```
+
+Approximate rates (verify against current Anthropic pricing):
+
+| Model | Input $/1K | Output $/1K |
+|-------|-----------|------------|
+| Haiku | $0.00080 | $0.00400 |
+| Sonnet | $0.01500 | $0.07500 |
+| Opus | $0.07500 | $0.37500 |
+
+### Budget Enforcement
+
+```python
+def check_budget(session: Session, estimated_cost: float) -> bool:
+    if session.current_spend + estimated_cost > session.limit_usd:
+        raise BudgetExceededError(
+            f"Estimated cost ${estimated_cost:.4f} would exceed session budget "
+            f"(${session.limit_usd}). Current spend: ${session.current_spend:.4f}."
+        )
+    return True
+```
+
+---
+
+## Caching Strategy
+
+### What to Cache
+
+| Content Type | Cache TTL | Notes |
+|--------------|-----------|-------|
+| GitHub repo metadata | 5 min | Changes infrequently |
+| npm/PyPI package info | 1 hour | Very stable |
+| Static document summaries | 24 hours | Regenerate on change |
+| Code review of unchanged diff | Permanent | Hash the diff |
+| Research reports | 7 days | Add staleness flag |
+
+### Cache Key Design
+
+```python
+def cache_key(model: str, prompt: str, system: str = "") -> str:
+    content = f"{model}|{system}|{prompt}"
+    return hashlib.sha256(content.encode()).hexdigest()
+```
+
+### Cache Hit Savings
+
+A cached Opus call that cost $0.10 on first run saves $0.10 on every subsequent hit. For repeated research tasks or common code patterns, caching can reduce effective cost by 50–80%.
+
+---
+
+## Escalation Protocol
+
+If a Haiku or Sonnet response is insufficient:
+
+1. **Haiku → Sonnet escalation**: Triggered when response contains uncertainty markers ("I'm not sure", "this may not be accurate", "you should verify") OR output is under 50 tokens for a complex request
+2. **Sonnet → Opus escalation**: Triggered when confidence is low AND the task is flagged as critical (security, production, architecture)
+3. **Human escalation**: Always available; triggered when any model expresses inability to complete the task
+
+---
+
+## Implementation Reference
+
+See `agents/cost-router/` for the cost-router agent implementation:
+- `agents/cost-router/AGENT.md` — Agent definition and responsibilities
+- `agents/cost-router/routing-rules.md` — Complete routing rule set with examples


### PR DESCRIPTION
## Summary

Implements a cost-aware LLM routing layer that intercepts all model calls and routes them to the cheapest capable tier.

## Changes

### `docs/cost-aware-routing.md`
- Model routing decision tree: Haiku → Sonnet → Opus
- Complexity scoring system (0–10)
- Cost tracking formulas with per-model rates
- Per-session budget enforcement ($0.50 default)
- Caching strategy with TTL by content type
- Escalation protocol between tiers

### `agents/cost-router/AGENT.md`
- Full cost-router agent definition
- Complexity scoring inputs and output schema
- Budget enforcement rules (per-call $0.25, per-session $0.50)
- Cache lookup integration with Redis/memory backends
- TypeScript interface definition for router API
- Monitoring dashboard metrics and SLOs

### `agents/cost-router/routing-rules.md`
- Complete routing rule set (priority-ordered, first-match-wins)
- Hard overrides: critical tasks min Sonnet, architecture → Opus
- Task type rules, complexity score rules
- Context length upgrade rules
- Keyword pattern rules (regex per tier)
- Annotated examples for Haiku, Sonnet, Opus routing

### `AGENTS.md`
- Added Cost-Aware Model Routing section with quick reference
- Model tier table and decision summary
- Budget enforcement overview

## Target Distribution
~60% Haiku · ~30% Sonnet · ~10% Opus

Closes #4