### PR TITLE
fix: Corrected model routing — Opus=Code, Sonnet=Planning, Haiku=Triage

### DIFF
--- a/docs/model-routing-guide.md
+++ b/docs/model-routing-guide.md
@@ -1,7 +1,21 @@
 # Model Routing Guide
 
-> **Goal:** ≥40% of tasks on Haiku · ≤50% on Sonnet · ≤10% on Opus  
-> **Why it matters:** Haiku is 10x cheaper than Sonnet, 19x cheaper than Opus.
+> **Goal:** ≥40% of tasks on Haiku · ≤30% on Sonnet · ≤30% on Opus  
+> **Why it matters:** Right model for the right job — quality where it counts, cost savings where it doesn't.
+
+---
+
+## ⚠️ CORRECTED Routing (Updated 2026-03-01)
+
+The routing was previously incorrect. **Opus is for code; Sonnet is for planning.**
+
+**Correct model assignments:**
+
+| Model | Role | Rationale |
+|-------|------|-----------|
+| **Haiku** | Triage & simple tasks | Fast, cheap, structured lookups |
+| **Sonnet** | Planning & strategy | Architecture decisions need reasoning, not raw code power |
+| **Opus** | Code & complex problem-solving | Correctness matters most — use the best model |
 
 ---
 
@@ -9,9 +23,9 @@
 
 | Model | Name | Cost / 1M tokens | Relative cost | Best for |
 |-------|------|-----------------|--------------|---------|
-| **Haiku** | `claude-haiku-4-5` | $0.80 | 1× (baseline) | Fast, simple, structured tasks |
-| **Sonnet** | `claude-sonnet-4-6` | $3.00 | 3.75× | Standard coding and analysis |
-| **Opus** | `claude-opus-4-5` | $15.00 | 18.75× | Deep reasoning, architecture |
+| **Haiku** | `claude-haiku-4-5` | $0.80 | 1× (baseline) | Fast triage, classification, status checks |
+| **Sonnet** | `claude-sonnet-4-6` | $3.00 | 3.75× | Planning, strategy, architecture design |
+| **Opus** | `claude-opus-4-5` | $15.00 | 18.75× | Code implementation, debugging, complex problem-solving |
 
 ---
 
@@ -28,34 +42,30 @@ Is there an AGENT-LEVEL OVERRIDE?
    ──────┴──────
    │             │
    ▼             ▼
-Use override   Is input context > 50,000 tokens?
+Use override   Is context > 50,000 tokens?
 model          │
-               │ YES → OPUS  (context too large for lighter models)
-               │
-               │ NO
-               ▼
-         Is input context > 2,000 tokens?
-               │
-               │ YES → at least SONNET
+               │ YES → OPUS  (code/complex work with large context)
                │
                │ NO
                ▼
          What is the task type?
 
    ┌──────────────────────────────────────────────────────┐
-   │  HAIKU tasks (simple/structured)                      │
+   │  HAIKU tasks (triage / simple / structured)           │
    │  triage · summary · format · lookup · notify          │
    │  classify · echo · status_check · board_update        │
    └──────────────────────────────────────────────────────┘
    ┌──────────────────────────────────────────────────────┐
-   │  SONNET tasks (standard complex work)                 │
-   │  code_review · implementation · debugging · analysis  │
-   │  planning · documentation · refactoring · test_writing│
+   │  SONNET tasks (planning / strategy / architecture)    │
+   │  planning · strategy · architecture_design            │
+   │  roadmapping · design_review · sprint_planning        │
+   │  ticket_breakdown · documentation                     │
    └──────────────────────────────────────────────────────┘
    ┌──────────────────────────────────────────────────────┐
-   │  OPUS tasks (deep reasoning only)                     │
-   │  architecture_design · security_audit                 │
-   │  complex_debugging · novel_problem · strategic_planning│
+   │  OPUS tasks (code / complex problem-solving)          │
+   │  implementation · code_review · debugging             │
+   │  refactoring · test_writing · security_audit          │
+   │  complex_debugging · novel_problem · analysis         │
    └──────────────────────────────────────────────────────┘
 
          │
@@ -70,9 +80,9 @@ model          │
 
 ## What Each Model Handles
 
-### 🟢 Haiku — Fast & Cheap (~40% of tasks)
+### 🟢 Haiku — Triage & Simple Tasks (~40% of tasks)
 
-**Use when:** the task is well-defined, context is small, output is structured or short.
+**Use when:** the task is well-defined, context is small, output is structured or short. No reasoning required.
 
 | Task | Example prompt |
 |------|---------------|
@@ -89,38 +99,46 @@ model          │
 
 ---
 
-### 🟡 Sonnet — Standard Work (~50% of tasks)
+### 🟡 Sonnet — Planning & Strategy (~30% of tasks)
 
-**Use when:** the task requires multi-step reasoning, code generation, or detailed analysis.
+**Use when:** the task requires structured thinking about *what* to build or *how* to approach a problem — but not yet writing the actual code.
 
 | Task | Example prompt |
 |------|---------------|
-| `code_review` | "Review this 200-line PR for correctness and style" |
-| `implementation` | "Implement the WebSocket reconnect logic per spec" |
-| `debugging` | "Why does this function return null on edge case X?" |
-| `analysis` | "Analyze these benchmark results and explain the regression" |
-| `planning` | "Break this epic into 5 actionable tickets" |
+| `planning` | "Break this epic into 5 actionable tickets with acceptance criteria" |
+| `strategy` | "Given our roadmap, what's the 6-month technical strategy?" |
+| `architecture_design` | "Design the data model for multi-tenant workspaces" |
+| `roadmapping` | "Prioritize these 20 backlog items for Q2" |
+| `sprint_planning` | "Plan this 2-week sprint given our velocity" |
+| `design_review` | "Review this architecture diagram for gaps" |
 | `documentation` | "Write API docs for these 10 endpoints" |
-| `refactoring` | "Refactor this class to use the repository pattern" |
-| `test_writing` | "Write unit tests for the auth module (aim for 80% coverage)" |
 
-**Cost at 1,000 req/day** (avg 2,000 tokens/req): ~$6/day → **$180/month**
+**Rationale:** Planning is about reasoning and trade-offs — Sonnet handles this well. Save Opus budget for *implementation*, where correctness matters most.
+
+**Cost at 300 req/day** (avg 3,000 tokens/req): ~$2.70/day → **$81/month**
 
 ---
 
-### 🔴 Opus — Deep Reasoning Only (~10% of tasks)
+### 🔴 Opus — Code & Complex Problem-Solving (~30% of tasks)
 
-**Use when:** the problem is genuinely novel, requires cross-system reasoning, or has very high stakes.
+**Use when:** writing, reviewing, or debugging actual code — or solving genuinely hard problems where quality is non-negotiable.
 
 | Task | Example prompt |
 |------|---------------|
-| `architecture_design` | "Design the multi-agent orchestration layer for our platform" |
-| `security_audit` | "Audit our entire MCP tool surface for privilege escalation vectors" |
+| `implementation` | "Implement the WebSocket reconnect logic per spec" |
+| `code_review` | "Review this 200-line PR for correctness, edge cases, and security" |
+| `debugging` | "Why does this function return null on edge case X?" |
+| `refactoring` | "Refactor this class to use the repository pattern" |
+| `test_writing` | "Write unit tests for the auth module (aim for 80% coverage)" |
 | `complex_debugging` | "This race condition manifests across 3 microservices — debug it" |
-| `novel_problem` | "We've never handled multi-tenant AI workloads — design the approach" |
-| `strategic_planning` | "Given our roadmap, what's the 6-month technical strategy?" |
+| `security_audit` | "Audit our MCP tool surface for privilege escalation vectors" |
+| `analysis` | "Analyze these benchmark results and explain the performance regression" |
 
-**Cost at 100 req/day** (avg 5,000 tokens/req): ~$7.50/day → **$225/month**
+**Rationale:** Code bugs cost real money and user trust. Opus's superior reasoning prevents subtle bugs that Sonnet would introduce — especially in edge cases and security-sensitive code.
+
+**Cost at 300 req/day** (avg 5,000 tokens/req): ~$22.50/day → **$675/month**
+
+> 💡 **Note:** Yes, Opus for code is more expensive than Sonnet. That's intentional. A single production bug can cost 10× more than the saved inference cost.
 
 ---
 
@@ -131,10 +149,10 @@ model          │
 ```yaml
 model:
   provider: "anthropic"
-  name: "claude-sonnet-4-6"      # default model
+  name: "claude-opus-4-5"          # default for code agents
   routing_enabled: true
   routing_config: "../../templates/model-routing.yaml"
-  routing_rationale: "Sonnet for standard tasks; Haiku for status checks"
+  routing_rationale: "Opus for code; Sonnet for planning; Haiku for triage"
 ```
 
 ### 2. Add `cost_controls` at the end of `agent.yaml`
@@ -142,34 +160,38 @@ model:
 ```yaml
 cost_controls:
   track_model_usage: true
-  alert_if_opus_percent_exceeds: 15
-  monthly_budget_usd: 50
+  alert_if_opus_percent_exceeds: 40
+  monthly_budget_usd: 800
   preferred_model_target:
-    haiku_min_percent: 40
-    sonnet_max_percent: 50
-    opus_max_percent: 10
+    haiku_target_percent: 40
+    sonnet_target_percent: 30
+    opus_target_percent: 30
 ```
 
 ### 3. Use the CLI router in your scripts
 
 ```bash
-# Get the model for a task type
+# Triage → Haiku
 MODEL=$(./scripts/route-model.sh --task-type triage)
 # → claude-haiku-4-5
 
-# With token count consideration
-MODEL=$(./scripts/route-model.sh --task-type implementation --context-tokens 8000)
+# Planning → Sonnet
+MODEL=$(./scripts/route-model.sh --task-type planning)
 # → claude-sonnet-4-6
+
+# Implementation → Opus
+MODEL=$(./scripts/route-model.sh --task-type implementation)
+# → claude-opus-4-5
 
 # With agent override
 MODEL=$(./scripts/route-model.sh --agent dispatcher --task-type analysis)
 # → claude-haiku-4-5  (dispatcher always uses Haiku)
 
 # With explanation
-./scripts/route-model.sh --task-type architecture_design --explain
-# [explain] Task type  : architecture_design → opus
+./scripts/route-model.sh --task-type implementation --explain
+# [explain] Task type  : implementation → opus
 # [explain] Token count: 0 → haiku
-# [explain] Decision   : Task type 'architecture_design' maps to opus
+# [explain] Decision   : Task type 'implementation' maps to opus (code quality)
 # [explain] Model      : claude-opus-4-5
 # claude-opus-4-5
 ```
@@ -180,65 +202,50 @@ MODEL=$(./scripts/route-model.sh --agent dispatcher --task-type analysis)
 
 | Anti-pattern | Why it's wrong | Fix |
 |-------------|----------------|-----|
+| Using Sonnet for code implementation | Correctness matters most — Sonnet misses edge cases | Use Opus |
+| Using Opus for sprint planning | Overkill; Sonnet handles strategic reasoning fine | Use Sonnet |
 | Using Opus for JSON formatting | 19× overpay for a deterministic task | Use Haiku |
-| Using Haiku for architecture design | Insufficient reasoning depth; bad output | Use Opus |
-| Using Haiku for 10k-token codebase review | Context too large; Haiku max is ~2k | Use Sonnet |
-| Using Sonnet for every single task | Overpaying for triage/status tasks | Route simple tasks to Haiku |
-| Using Opus as the "safe default" | Budget killer; rarely justified | Opus only for truly novel problems |
-| Ignoring token count in routing | A "summary" task with 60k context needs Opus | Always factor in context size |
-
----
-
-## ROI Calculation
-
-### Baseline (no routing — everything on Sonnet)
-- 1,000 req/day × avg 2,000 tokens × $3.00/1M = **$6.00/day → $180/month**
-
-### With routing (40% Haiku / 50% Sonnet / 10% Opus)
-
-| Tier | Requests/day | Avg tokens | Cost/1M | Daily cost |
-|------|-------------|-----------|---------|-----------|
-| Haiku  | 400 | 800   | $0.80  | $0.26 |
-| Sonnet | 500 | 2,000 | $3.00  | $3.00 |
-| Opus   | 100 | 5,000 | $15.00 | $7.50 |
-| **Total** | **1,000** | | | **$10.76/day** |
-
-**Monthly: ~$323** — *but the Opus tasks were previously impossible on Sonnet, so we're not comparing apples-to-apples.*
-
-### Apples-to-apples: routing simple tasks off Sonnet
-
-| Scenario | Monthly cost |
-|----------|-------------|
-| No routing (all Sonnet, 1,000 req/day) | $180/month |
-| With routing (40% to Haiku, no Opus) | ~$116/month |
-| **Savings** | **~$64/month (36% reduction)** |
-
-At 5,000 req/day, that savings becomes **~$320/month** — just from routing obvious Haiku tasks off Sonnet.
+| Using Haiku for architecture design | Insufficient reasoning depth; bad output | Use Sonnet |
+| Using Haiku for coding tasks | Insufficient capability for correctness | Use Opus |
+| Using Sonnet as "safe default" for everything | Misses the code-quality benefit of Opus | Route per task type |
+| Ignoring token count in routing | A "summary" with 60k context needs escalation | Always factor context size |
 
 ---
 
 ## Quick Reference Card
 
 ```
-Task type          → Model    Why
-─────────────────────────────────────────────────────
-triage             → Haiku    classify only
-summary            → Haiku    structured output
-format             → Haiku    deterministic transform
-status_check       → Haiku    yes/no answer
-board_update       → Haiku    structured action
-code_review        → Sonnet   multi-step reasoning
-implementation     → Sonnet   code generation
-debugging          → Sonnet   analysis + code
-analysis           → Sonnet   detailed reasoning
-planning           → Sonnet   structured output + reasoning
-documentation      → Sonnet   long-form, detail
-refactoring        → Sonnet   code understanding + output
-architecture       → Opus     novel design, high stakes
-security_audit     → Opus     adversarial reasoning
-complex_debugging  → Opus     cross-system, no pattern
+Task type            → Model    Why
+─────────────────────────────────────────────────────────
+triage               → Haiku    classify only
+summary              → Haiku    structured output
+format               → Haiku    deterministic transform
+status_check         → Haiku    yes/no answer
+board_update         → Haiku    structured action
+planning             → Sonnet   strategy + trade-offs
+architecture_design  → Sonnet   design reasoning
+roadmapping          → Sonnet   prioritization logic
+sprint_planning      → Sonnet   structured planning
+documentation        → Sonnet   long-form, structured
+implementation       → Opus     code correctness matters
+code_review          → Opus     catch edge cases + bugs
+debugging            → Opus     deep reasoning required
+refactoring          → Opus     correctness-critical
+test_writing         → Opus     thoroughness required
+security_audit       → Opus     adversarial reasoning
+complex_debugging    → Opus     cross-system, no pattern
 ```
 
 ---
 
-*Maintained by JarvisXomware · Last updated 2026-02-28*
+## Previous (Incorrect) Routing — For Reference
+
+The old guide incorrectly assigned Sonnet to code tasks and Opus to architecture/planning. This was wrong because:
+
+1. **Code quality is the highest-stakes output** — bugs in production cost more than inference savings
+2. **Planning is reasoning, not raw intelligence** — Sonnet handles strategic reasoning well
+3. **Opus budget was wasted on docs and planning** — which are low-correctness-risk tasks
+
+---
+
+*Maintained by JarvisXomware · Last updated 2026-03-01*

--- a/templates/model-routing.yaml
+++ b/templates/model-routing.yaml
@@ -1,15 +1,24 @@
 # Model Routing Decision Tree for Xomware Claude Agents
-# Version: 1.0.0
-# Purpose: Route tasks to correct model tier for cost optimization
-# Target: ≥40% Haiku, ≤50% Sonnet, ≤10% Opus
+# Version: 2.0.0
+# Purpose: Route tasks to correct model tier — quality where it counts, savings where it doesn't
+# CORRECTED 2026-03-01: Opus=Code, Sonnet=Planning, Haiku=Triage
+#
+# ⚠️  IMPORTANT CHANGE from v1.0.0:
+#     OLD (incorrect): Sonnet=Code, Opus=Architecture/Strategy
+#     NEW (correct):   Opus=Code, Sonnet=Planning/Strategy, Haiku=Triage
+#
+# Rationale: Code correctness is the highest-stakes output. Opus prevents bugs
+# that Sonnet misses. Planning is reasoning-heavy but not correctness-critical —
+# Sonnet handles it well at 5x lower cost.
 
 metadata:
-  version: "1.0.0"
-  last_updated: "2026-02-28"
+  version: "2.0.0"
+  last_updated: "2026-03-01"
+  changelog: "CORRECTED routing: Opus for code, Sonnet for planning, Haiku for triage"
   cost_targets:
-    haiku_min_percent: 40
-    sonnet_max_percent: 50
-    opus_max_percent: 10
+    haiku_target_percent: 40
+    sonnet_target_percent: 30
+    opus_target_percent: 30
 
 models:
   haiku:
@@ -18,6 +27,7 @@ models:
     cost_tier: "low"
     max_tokens: 1000
     latency_profile: "fast"  # <500ms typical
+    role: "triage"
     
   sonnet:
     name: "claude-sonnet-4-6"
@@ -25,6 +35,7 @@ models:
     cost_tier: "medium"
     max_tokens: 8000
     latency_profile: "moderate"  # 1-3s typical
+    role: "planning"
     
   opus:
     name: "claude-opus-4-5"
@@ -32,27 +43,29 @@ models:
     cost_tier: "high"
     max_tokens: 32000
     latency_profile: "slow"  # 5-15s typical
+    role: "code"
 
 routing_rules:
   haiku:
-    description: "Simple, fast, cheap — ~40% of tasks"
+    description: "Triage & simple structured tasks — ~40% of tasks"
+    role: "triage"
     use_when:
       task_types:
-        - triage         # Classify/route requests
-        - summary        # Summarize text or data
-        - format         # Reformat/transform structured data
-        - lookup         # Simple fact retrieval
-        - notify         # Compose notifications/alerts
-        - classify       # Label or categorize items
-        - echo           # Pass-through or relay responses
-        - status_check   # Check if something is up/running
-        - board_update   # Update board status
+        - triage          # Classify/route requests
+        - summary         # Summarize text or data
+        - format          # Reformat/transform structured data
+        - lookup          # Simple fact retrieval
+        - notify          # Compose notifications/alerts
+        - classify        # Label or categorize items
+        - echo            # Pass-through or relay responses
+        - status_check    # Check if something is up/running
+        - board_update    # Update board status
       context_thresholds:
         max_input_tokens: 2000
       output_types:
         - structured_json
         - structured_yaml
-        - short_text     # <200 words expected output
+        - short_text      # <200 words expected output
     examples:
       - "Is this PR ready to merge?"
       - "Format this JSON"
@@ -61,52 +74,71 @@ routing_rules:
       - "Send this notification"
 
   sonnet:
-    description: "Standard complex work — ~50% of tasks"
+    description: "Planning, strategy, and architecture — ~30% of tasks"
+    role: "planning"
+    rationale: >
+      Sonnet handles strategic reasoning and planning well at 5x lower cost than Opus.
+      Planning tasks are reasoning-heavy but not correctness-critical — a suboptimal
+      plan can be revised, but a buggy deployment cannot be easily recalled.
     use_when:
       task_types:
-        - code_review
-        - implementation
-        - debugging
-        - analysis
-        - planning
-        - documentation
-        - refactoring
-        - test_writing
+        - planning           # Sprint/epic/project planning
+        - strategy           # Technical strategy and direction
+        - architecture_design # System/service architecture (design phase)
+        - roadmapping        # Backlog prioritization and scheduling
+        - sprint_planning    # 2-week sprint composition
+        - design_review      # Architecture/design critique
+        - documentation      # Writing docs, READMEs, runbooks
+        - ticket_breakdown   # Breaking epics into stories
       context_thresholds:
-        min_input_tokens: 2000
+        min_input_tokens: 1000
         max_input_tokens: 50000
       output_types:
-        - code
-        - long_form_text   # >200 words expected
-        - detailed_analysis
+        - architecture_document
+        - plan_document
+        - long_form_text    # >200 words expected
     examples:
-      - "Review this PR"
-      - "Implement this feature"
-      - "Write tests for this module"
-      - "Analyze this error"
-      - "Plan this sprint"
+      - "Break this epic into 5 actionable tickets"
+      - "Design the data model for multi-tenant workspaces"
+      - "Plan this 2-week sprint given our velocity"
+      - "Write API docs for these 10 endpoints"
+      - "What's the 6-month technical strategy?"
 
   opus:
-    description: "Deep reasoning only — ~10% of tasks"
+    description: "Code implementation & complex problem-solving — ~30% of tasks"
+    role: "code"
+    rationale: >
+      Opus for code is non-negotiable. Code bugs cost real money and user trust.
+      Opus's superior reasoning prevents subtle bugs that Sonnet would introduce —
+      especially in edge cases, security-sensitive code, and multi-system debugging.
+      Yes, it's more expensive. A single production incident costs 10x more.
     use_when:
       task_types:
-        - architecture_design
-        - security_audit
-        - complex_debugging    # Multi-system, hard to reproduce
-        - novel_problem        # No prior pattern exists
-        - strategic_planning   # Long-horizon decisions
+        - implementation     # Writing new code / features
+        - code_review        # Reviewing PRs for correctness and security
+        - debugging          # Finding and fixing bugs
+        - refactoring        # Structural code improvements
+        - test_writing       # Writing unit/integration/e2e tests
+        - complex_debugging  # Multi-system, hard-to-reproduce issues
+        - security_audit     # Adversarial analysis of code/config
+        - analysis           # Performance analysis, root-cause analysis
+        - novel_problem      # No prior pattern exists
       context_thresholds:
-        min_input_tokens: 50000
+        min_input_tokens: 500
       output_types:
-        - architecture_document
+        - code
+        - diff
         - security_report
         - deep_analysis
     examples:
-      - "Design the multi-agent orchestration architecture"
-      - "Audit our entire MCP tool surface for security"
-      - "Debug this intermittent race condition across 3 services"
+      - "Implement the WebSocket reconnect logic per spec"
+      - "Review this PR for correctness and edge cases"
+      - "Write unit tests for the auth module (80% coverage)"
+      - "Debug this race condition in the payment processor"
+      - "Refactor the notification service to use event sourcing"
 
-# Agent-specific defaults (override above rules)
+# Agent-specific defaults
+# These override routing rules for specific agent roles.
 agent_defaults:
   dispatcher:
     default_model: "haiku"
@@ -115,20 +147,42 @@ agent_defaults:
     
   orchestrator:
     default_model: "sonnet"
-    rationale: "Orchestration requires multi-step reasoning but not frontier-level"
+    rationale: "Orchestration is planning-heavy; Sonnet handles coordination well"
     
   forge-code:
-    default_model: "sonnet"
-    rationale: "Code work needs Sonnet; Opus only for architecture reviews"
+    default_model: "opus"
+    rationale: "Code agents use Opus by default — correctness is paramount"
+    escalate_to: "opus"  # Never downgrade code work
     
   recon-research:
     default_model: "sonnet"
-    rationale: "Research synthesis needs Sonnet; Opus for novel research questions"
+    rationale: "Research synthesis and planning use Sonnet; Opus for implementation"
     
   scribe-docs:
-    default_model: "haiku"
-    rationale: "Documentation formatting/summarization is Haiku territory"
+    default_model: "sonnet"
+    rationale: "Documentation is planning-tier; Sonnet is appropriate"
     
   deployer-devops:
-    default_model: "sonnet"
-    rationale: "DevOps tasks vary; default Sonnet with Haiku for status checks"
+    default_model: "opus"
+    rationale: "Infrastructure-as-code and deployment scripts are code — use Opus"
+    note: "Status checks within deployer tasks still use Haiku"
+
+# Escalation rules
+escalation:
+  context_size_thresholds:
+    force_opus_above_tokens: 50000
+    prefer_sonnet_above_tokens: 5000
+  
+  quality_gates:
+    # Tasks that should NEVER be downgraded below Opus
+    opus_required:
+      - security_audit
+      - production_deployment
+      - database_migration
+      - complex_debugging
+    
+    # Tasks that should NEVER be upgraded above Sonnet
+    sonnet_max:
+      - planning
+      - documentation
+      - design_review


### PR DESCRIPTION
## Problem

The model routing guide and YAML template had the wrong model assignments:

| Task | Old (wrong) | New (correct) |
|------|------------|---------------|
| Code implementation | Sonnet | **Opus** |
| Architecture/planning | Opus | **Sonnet** |
| Triage/status | Haiku | Haiku (unchanged) |

## Why This Matters

**Code correctness is the highest-stakes output.** A bug in production costs far more than the difference between Sonnet and Opus inference. Opus catches edge cases, security issues, and subtle logic errors that Sonnet routinely misses.

**Planning is reasoning, not raw intelligence.** Sonnet handles strategic trade-offs and architecture design well at 5× lower cost. A suboptimal plan can be revised; a buggy deployment cannot.

## Changes

### `docs/model-routing-guide.md`
- Updated decision flowchart with correct task→model mapping
- Rewrote Sonnet section: planning/strategy/architecture
- Rewrote Opus section: implementation/code review/debugging
- Added anti-patterns for the old incorrect routing
- Added rationale section explaining the change

### `templates/model-routing.yaml` (v2.0.0)
- Corrected all `task_types` under each model tier
- Updated `agent_defaults`: forge-code → opus, deployer-devops → opus, scribe-docs → sonnet
- Added `escalation.quality_gates` (opus_required list, sonnet_max list)
- Added `role` fields: haiku=triage, sonnet=planning, opus=code

## Testing
- Model routing script will be tested with implementation, planning, and triage task types
- MEMORY.md and workspace-herald docs updated separately

## Downstream
After merge: MEMORY.md and Boris AGENTS.md will be updated to reflect correct routing.